### PR TITLE
Auto-update Braiins Toolbox and Manager Agent on startup

### DIFF
--- a/braiins-manager-agent/Dockerfile
+++ b/braiins-manager-agent/Dockerfile
@@ -14,7 +14,10 @@ ARG BUILD_VERSION
 # Install requirements for add-on
 RUN apk add --no-cache \
     coreutils \
-    wget
+    wget \
+    curl \
+    binutils \
+    xz
 
 # Copy root filesystem
 COPY rootfs /

--- a/braiins-manager-agent/config.yaml
+++ b/braiins-manager-agent/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Braiins Manager Agent"
-version: "4.1.4"
+version: "4.1.5"
 slug: "braiins-manager-agent"
 description: "Remotely manage and monitor your mining hardware through the Braiins Manager platform"
 url: "https://github.com/Donach/ha-addons/tree/main/braiins-manager-agent"

--- a/braiins-manager-agent/run.sh
+++ b/braiins-manager-agent/run.sh
@@ -37,5 +37,74 @@ fi
 echo "daemon.yaml:"
 cat /etc/braiins-manager-agent/daemon.yaml
 
+# Update Braiins Manager Agent binary
+bashio::log.info "Checking for Braiins Manager Agent updates..."
+
+# Architecture mapping
+case "$(bashio::info.arch)" in
+    "amd64")
+        ARCH="x86_64"
+        ;;
+    "aarch64")
+        ARCH="aarch64"
+        ;;
+    *)
+        bashio::log.warning "Unsupported architecture for updates: $(bashio::info.arch)"
+        ARCH=""
+        ;;
+esac
+
+if [ -n "${ARCH}" ]; then
+    LATEST_VERSION=$(curl -s https://downloads.braiins.com/braiins-manager-agent/ | grep -oE 'assets/[0-9.]+' | cut -d/ -f2 | sort -V | tail -n 1)
+
+    if [ -n "${LATEST_VERSION}" ]; then
+        bashio::log.info "Latest version found: ${LATEST_VERSION}"
+        DOWNLOAD_URL="https://downloads.braiins.com/braiins-manager-agent/assets/${LATEST_VERSION}/braiins-manager-agent-linux-${ARCH}.deb"
+
+        # Create temp dir
+        TEMP_DIR=$(mktemp -d)
+        cd "${TEMP_DIR}"
+
+        bashio::log.info "Downloading update from ${DOWNLOAD_URL}..."
+        if curl -L -f --connect-timeout 30 --max-time 300 -o "agent.deb" "${DOWNLOAD_URL}"; then
+            bashio::log.info "Download successful, extracting..."
+
+            # Extract deb package
+            if ar x agent.deb; then
+                # Extract data archive (usually data.tar.xz or data.tar.gz)
+                DATA_TAR=$(find . -name "data.tar*" | head -1)
+                if [ -n "${DATA_TAR}" ]; then
+                    if tar -xf "${DATA_TAR}"; then
+                        # Find the binary
+                        NEW_BINARY=$(find . -name "bma-daemon" -type f | head -1)
+                        if [ -n "${NEW_BINARY}" ]; then
+                            bashio::log.info "Replacing binary..."
+                            cp "${NEW_BINARY}" /usr/bin/bma-daemon
+                            chmod +x /usr/bin/bma-daemon
+                            bashio::log.info "Update complete."
+                        else
+                            bashio::log.error "Could not find bma-daemon binary in extracted package."
+                        fi
+                    else
+                        bashio::log.error "Failed to extract ${DATA_TAR}"
+                    fi
+                else
+                    bashio::log.error "Could not find data.tar archive in deb package."
+                fi
+            else
+                bashio::log.error "Failed to extract deb package."
+            fi
+        else
+            bashio::log.warning "Failed to download update."
+        fi
+
+        # Cleanup
+        cd /
+        rm -rf "${TEMP_DIR}"
+    else
+        bashio::log.warning "Failed to fetch latest version info."
+    fi
+fi
+
 # Start the daemon
 exec /usr/bin/bma-daemon

--- a/braiins-toolbox/Dockerfile
+++ b/braiins-toolbox/Dockerfile
@@ -20,7 +20,8 @@ RUN apk add --no-cache \
     curl \
     tar \
     gzip \
-    ca-certificates
+    ca-certificates \
+    coreutils
 
 # Copy run script
 COPY run.sh /run.sh

--- a/braiins-toolbox/config.yaml
+++ b/braiins-toolbox/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Braiins Toolbox"
-version: "25.03.0"
+version: "25.03.1"
 slug: "braiins-toolbox"
 description: "Braiins Toolbox - Bitcoin mining farm management software with web interface"
 url: "https://github.com/Donach/ha-addons/tree/main/braiins-toolbox"

--- a/braiins-toolbox/run.sh
+++ b/braiins-toolbox/run.sh
@@ -25,6 +25,23 @@ esac
 
 bashio::log.info "Starting Braiins Toolbox for architecture: ${ARCH}"
 
+# Fetch latest version if auto-update is enabled
+if [ "${AUTO_UPDATE}" = "true" ]; then
+    bashio::log.info "Checking for latest Braiins Toolbox version..."
+    LATEST_VERSION=$(curl -s https://downloads.braiins.com/braiins-toolbox/ | grep -oE 'assets/[0-9.]+' | cut -d/ -f2 | sort -V | tail -n 1)
+
+    if [ -n "${LATEST_VERSION}" ]; then
+        if [ "${LATEST_VERSION}" != "${BRAIINS_TOOLBOX_VERSION}" ]; then
+            bashio::log.info "New version found: ${LATEST_VERSION} (current configured: ${BRAIINS_TOOLBOX_VERSION})"
+            BRAIINS_TOOLBOX_VERSION="${LATEST_VERSION}"
+        else
+            bashio::log.info "Already using the latest version: ${BRAIINS_TOOLBOX_VERSION}"
+        fi
+    else
+        bashio::log.warning "Failed to fetch latest version, using configured version: ${BRAIINS_TOOLBOX_VERSION}"
+    fi
+fi
+
 # Download URL
 DOWNLOAD_URL="https://downloads.braiins.com/braiins-toolbox/assets/${BRAIINS_TOOLBOX_VERSION}/braiins-toolbox-linux-${ARCH}.tar.gz"
 TOOLBOX_DIR="/opt/braiins-toolbox"
@@ -33,6 +50,7 @@ BINARY_PATH="${TOOLBOX_DIR}/braiins-toolbox"
 # Function to download and extract Braiins Toolbox
 download_toolbox() {
     bashio::log.info "Downloading Braiins Toolbox ${BRAIINS_TOOLBOX_VERSION} for ${ARCH}..."
+    bashio::log.info "Download URL: ${DOWNLOAD_URL}"
     
     # Create temporary directory
     TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
Reworked the addon for both braiins toolbox and braiins manager agent to automatically update the respective binaries on addon reset. Look for latest versions available from "https://downloads.braiins.com" and replace the existing version on addon start.

---
*PR created automatically by Jules for task [15142043860950801403](https://jules.google.com/task/15142043860950801403) started by @Donach*