### PR TITLE
feat: Add RustBerry PoE Monitor Add-on

### DIFF
--- a/rustberry-poe-monitor/DOCS.md
+++ b/rustberry-poe-monitor/DOCS.md
@@ -1,0 +1,40 @@
+# RustBerry PoE Monitor Add-on
+
+This add-on runs the [RustBerry-PoE-Monitor](https://github.com/jackra1n/RustBerry-PoE-Monitor) to control the display and fan of the Raspberry Pi Waveshare PoE HAT (B).
+
+## Prerequisites
+
+### Enable I2C
+
+The add-on requires I2C to be enabled on your Raspberry Pi to communicate with the OLED display.
+
+If you are using Home Assistant OS, you may need to enable I2C manually. Please refer to the [Home Assistant documentation on enabling I2C](https://www.home-assistant.io/common-tasks/os/#enabling-i2c).
+
+## Installation
+
+1.  Add this repository to your Home Assistant Add-on Store.
+2.  Install the "RustBerry PoE Monitor" add-on.
+3.  Start the add-on.
+
+## Configuration
+
+The add-on can be configured via the "Configuration" tab.
+
+### Display
+
+*   **brightness**: OLED brightness level (0-4). Default: 2.
+*   **screen_timeout**: Time in seconds before the screen dims (0 to disable). Default: 300.
+*   **enable_periodic_off**: Enable periodic display on/off cycle to prevent burn-in. Default: false.
+*   **periodic_on_duration**: Duration (seconds) the display stays ON. Default: 10.
+*   **periodic_off_duration**: Duration (seconds) the display stays OFF. Default: 20.
+*   **refresh_interval_ms**: Refresh interval in milliseconds. Default: 1000.
+
+### Fan
+
+*   **temp_on**: Temperature (Celsius) at which the fan turns on. Default: 60.0.
+*   **temp_off**: Temperature (Celsius) at which the fan turns off. Default: 50.0.
+
+## Support
+
+If you encounter issues, please check the add-on logs.
+For issues related to the underlying tool, visit the [RustBerry-PoE-Monitor repository](https://github.com/jackra1n/RustBerry-PoE-Monitor).

--- a/rustberry-poe-monitor/Dockerfile
+++ b/rustberry-poe-monitor/Dockerfile
@@ -1,0 +1,60 @@
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
+# Build arguments
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+
+# Install requirements for add-on
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        jq \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download RustBerry PoE Monitor
+RUN \
+    if [ "${BUILD_ARCH}" = "aarch64" ]; then \
+        BINARY_NAME="rustberry-poe-monitor-aarch64"; \
+    elif [ "${BUILD_ARCH}" = "armv7" ]; then \
+        BINARY_NAME="rustberry-poe-monitor-armv7l"; \
+    else \
+        echo "Unsupported architecture: ${BUILD_ARCH}"; \
+        exit 1; \
+    fi \
+    && echo "Downloading ${BINARY_NAME}..." \
+    && curl -L -o /usr/local/bin/rustberry-poe-monitor \
+        "https://github.com/jackra1n/RustBerry-PoE-Monitor/releases/download/1.2.0/${BINARY_NAME}" \
+    && chmod +x /usr/local/bin/rustberry-poe-monitor
+
+# Copy run script
+COPY run.sh /run.sh
+RUN chmod a+x /run.sh
+
+# Labels
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="Donach <donach.cz@gmail.com>" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Donach's Add-ons" \
+    org.opencontainers.image.authors="Donach <donach.cz@gmail.com>" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/jackra1n/RustBerry-PoE-Monitor" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/rustberry-poe-monitor/DOCS.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version=${BUILD_VERSION}
+
+CMD [ "/run.sh" ]

--- a/rustberry-poe-monitor/build.yaml
+++ b/rustberry-poe-monitor/build.yaml
@@ -1,0 +1,10 @@
+build_from:
+  aarch64: ghcr.io/hassio-addons/debian-base:7.6.2
+  armv7: ghcr.io/hassio-addons/debian-base:7.6.2
+codenotary:
+  base_image: codenotary@frenck.dev
+  signer: codenotary@frenck.dev
+labels:
+  io.hass.name: "RustBerry PoE Monitor"
+  io.hass.description: "Monitor and control Raspberry Pi PoE HAT (B) with OLED display"
+  io.hass.type: addon

--- a/rustberry-poe-monitor/config.yaml
+++ b/rustberry-poe-monitor/config.yaml
@@ -1,0 +1,39 @@
+name: "RustBerry PoE Monitor"
+version: "1.2.0"
+slug: "rustberry-poe-monitor"
+description: "A controller for the display and fan of the Raspberry Pi Waveshare PoE HAT (B)"
+url: "https://github.com/jackra1n/RustBerry-PoE-Monitor"
+arch:
+  - aarch64
+  - armv7
+startup: application
+boot: auto
+init: false
+host_network: true
+privileged: true
+devices:
+  - /dev/i2c-1
+  - /dev/gpiomem
+options:
+  display:
+    brightness: 2
+    screen_timeout: 300
+    enable_periodic_off: false
+    periodic_on_duration: 10
+    periodic_off_duration: 20
+    refresh_interval_ms: 1000
+  fan:
+    temp_on: 60.0
+    temp_off: 50.0
+schema:
+  display:
+    brightness: int(0,4)
+    screen_timeout: int(0,)
+    enable_periodic_off: bool
+    periodic_on_duration: int(1,)
+    periodic_off_duration: int(1,)
+    refresh_interval_ms: int(100,)
+  fan:
+    temp_on: float(0.0,)
+    temp_off: float(0.0,)
+image: "ghcr.io/donach/rustberry-poe-monitor-{arch}"

--- a/rustberry-poe-monitor/run.sh
+++ b/rustberry-poe-monitor/run.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+CONFIG_DIR="/root/.config/rustberry-poe-monitor"
+CONFIG_FILE="$CONFIG_DIR/config.toml"
+
+# Ensure config directory exists
+mkdir -p "$CONFIG_DIR"
+
+echo "Reading configuration from options.json..."
+
+# Extract values using jq
+BRIGHTNESS=$(jq -r '.display.brightness' /data/options.json)
+SCREEN_TIMEOUT=$(jq -r '.display.screen_timeout' /data/options.json)
+ENABLE_PERIODIC_OFF=$(jq -r '.display.enable_periodic_off' /data/options.json)
+PERIODIC_ON_DURATION=$(jq -r '.display.periodic_on_duration' /data/options.json)
+PERIODIC_OFF_DURATION=$(jq -r '.display.periodic_off_duration' /data/options.json)
+REFRESH_INTERVAL_MS=$(jq -r '.display.refresh_interval_ms' /data/options.json)
+TEMP_ON=$(jq -r '.fan.temp_on' /data/options.json)
+TEMP_OFF=$(jq -r '.fan.temp_off' /data/options.json)
+
+echo "Generating config.toml..."
+
+cat > "$CONFIG_FILE" <<EOF
+[display]
+brightness = ${BRIGHTNESS}
+screen_timeout = ${SCREEN_TIMEOUT}
+enable_periodic_off = ${ENABLE_PERIODIC_OFF}
+periodic_on_duration = ${PERIODIC_ON_DURATION}
+periodic_off_duration = ${PERIODIC_OFF_DURATION}
+refresh_interval_ms = ${REFRESH_INTERVAL_MS}
+
+[fan]
+temp_on = ${TEMP_ON}
+temp_off = ${TEMP_OFF}
+EOF
+
+echo "Configuration generated at $CONFIG_FILE"
+echo "Starting RustBerry PoE Monitor..."
+
+exec /usr/local/bin/rustberry-poe-monitor


### PR DESCRIPTION
This PR introduces a new Home Assistant add-on for the RustBerry PoE Monitor. The add-on allows users to control the fan and display of the Raspberry Pi Waveshare PoE HAT (B). It is configured to run with privileged access to interact with the I2C bus and GPIO pins. The add-on uses a Debian-based image to support the pre-compiled glibc binary provided by the upstream project. configuration is dynamically generated at startup based on user options.

---
*PR created automatically by Jules for task [1400568440782829017](https://jules.google.com/task/1400568440782829017) started by @Donach*